### PR TITLE
fix: use explicit window.exports reference in base64 library

### DIFF
--- a/sources/libraries/base64.js
+++ b/sources/libraries/base64.js
@@ -1,8 +1,8 @@
 'use strict'
 
-exports.byteLength = byteLength
-exports.toByteArray = toByteArray
-exports.fromByteArray = fromByteArray
+window.exports.byteLength = byteLength
+window.exports.toByteArray = toByteArray
+window.exports.fromByteArray = fromByteArray
 
 var lookup = []
 var revLookup = []


### PR DESCRIPTION
## Problem

Recent browser updates changed how strict mode JavaScript resolves unqualified identifiers like `exports` in extension contexts. The base64 library uses CommonJS-style exports which no longer properly resolve to `window.exports`.

This causes password authentication to fail for all users. Multiple users have reported this issue.

## Solution

Explicitly reference `window.exports` instead of relying on implicit global resolution.

## Compatibility

- Backward compatible - existing encrypted bookmarks decrypt correctly
- Works on both Firefox and Chrome (Manifest V2)

## Important Note

**This PR targets the 0.1.x codebase** (the version currently published on AMO as 0.1.19a). 

The current `master` branch contains a TypeScript rewrite (0.2.x) that doesn't have this issue since it uses native `btoa`/`atob`.

To merge this fix, you would need to:
1. Create a `0.1.x` maintenance branch from commit `9dd4dbf` (Bump version to 0.1.20)
2. Merge this PR into that branch
3. Release to AMO

Alternatively, releasing the 0.2.x TypeScript version to AMO would also fix this for users.